### PR TITLE
Patch to token_auth app settings processor

### DIFF
--- a/project/token_auth/settings.py
+++ b/project/token_auth/settings.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 # First look at TOKEN_AUTH_URL_PREFIX setting
 # If not set, try API_ROOT
-TOKEN_AUTH_URL_PREFIX = getattr(settings, 'TOKEN_AUTH_URL_PREFIX', '/')
+TOKEN_AUTH_URL_PREFIX = getattr(settings, 'TOKEN_AUTH_URL_PREFIX', None)
 if not TOKEN_AUTH_URL_PREFIX:
     TOKEN_AUTH_URL_PREFIX = getattr(settings, 'API_ROOT', '/')
 


### PR DESCRIPTION
`getattr` for `TOKEN_AUTH_URL_PREFIX` should default to None, so that the following check
`if not TOKEN_AUTH_URL_PREFIX` works correctly and checks `API_ROOT`.