### PR TITLE
[backend] Fixed handling of withdrawn products and shops

### DIFF
--- a/project/api/models/product.py
+++ b/project/api/models/product.py
@@ -6,15 +6,9 @@ class ProductTag(models.Model):
 
     def __str__(self):
         return self.tag
-    
+
     def __serialize__(self):
         return self.tag
-
-
-class BaseProductManager(models.Manager):
-    def get_queryset(self):
-        '''Omit withdrawn products from results by default'''
-        return super().get_queryset().filter(withdrawn=False)
 
 
 class ProductQuerySet(models.QuerySet):
@@ -26,8 +20,7 @@ class ProductQuerySet(models.QuerySet):
 
 # Adapted from:
 # https://docs.djangoproject.com/en/2.1/topics/db/managers/#from-queryset
-ProductManager = BaseProductManager.from_queryset(ProductQuerySet)
-
+ProductManager = models.Manager.from_queryset(ProductQuerySet)
 
 class Product(models.Model):
 
@@ -47,7 +40,7 @@ class Product(models.Model):
     objects = ProductManager()
 
     def __str__(self):
-        return self.name
+        return self.name + (' (withdrawn)' if self.withdrawn else '')
 
     def __serialize__(self):
         return {

--- a/project/api/models/shop.py
+++ b/project/api/models/shop.py
@@ -19,11 +19,6 @@ class ShopTag(models.Model):
         return self.tag
 
 
-class BaseShopManager(models.Manager):
-    def get_queryset(self):
-        '''Omit withdrawn shops from results by default'''
-        return super().get_queryset().filter(withdrawn=False)
-
 class ShopQuerySet(models.QuerySet):
     def within_distance_from(self, lat, lng, **distance):
         '''Find shops within given distance from given point.
@@ -72,7 +67,7 @@ class ShopQuerySet(models.QuerySet):
 #
 # Adapted from:
 # https://docs.djangoproject.com/en/2.1/topics/db/managers/#from-queryset
-ShopManager = BaseShopManager.from_queryset(ShopQuerySet)
+ShopManager = models.Manager.from_queryset(ShopQuerySet)
 
 
 class Shop(models.Model):
@@ -100,7 +95,7 @@ class Shop(models.Model):
     objects = ShopManager()
 
     def __str__(self):
-        return self.name
+        return self.name + (' (withdrawn)' if self.withdrawn else '')
 
     def __serialize__(self):
         return {

--- a/project/api/tests/integration.py
+++ b/project/api/tests/integration.py
@@ -127,7 +127,7 @@ class IntegrationTests:
         # TEST SENARIO
         ########################################################################
         def test_client(self):
-            '''run test client. implemented as a single test, to ensure that the actions happen in the correct order'''
+            '''integration tests, based on test client'''
 
             # register and login
             self.runTest('user_registers') # extra
@@ -156,9 +156,12 @@ class IntegrationTests:
 
         def runTest(self, testName):
             '''run action `testName`, while printing a good informative message'''
-            print(testName.ljust(40, '.'), end='')
-            getattr(self, testName)()
-            print('OK')
+            with self.subTest(testName):
+                print(testName.ljust(40, '.'), end='')
+                getattr(self, testName)()
+
+                # if we reach this, test `testName` has passed
+                print('OK')
 
         def assertShopsEqual(self, shop_1, shop_2):
             '''check that two shops are equal (equality check is not good enough, tags may be in different order'''
@@ -295,8 +298,10 @@ class IntegrationTests:
             )
             self.assertEqual(r.status_code, 200)
 
+            # check that shop is withdrawn
             r = requests.get(self.live_server_url + urls['shops'] + '2')
-            self.assertEqual(r.status_code, 404)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['withdrawn'], True)
 
 
         ########################################################################
@@ -367,5 +372,7 @@ class IntegrationTests:
             )
             self.assertEqual(r.status_code, 200)
 
+            # check that product is withdrawn
             r = requests.get(self.live_server_url + urls['products'] + '2')
-            self.assertEqual(r.status_code, 404)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['withdrawn'], True)

--- a/project/api/tests/test_product.py
+++ b/project/api/tests/test_product.py
@@ -38,14 +38,16 @@ class ProductTestCase(TestCase):
         # Check if product is accessible from tag
         self.assertTrue(self.product in tag.product_set.all())
 
-    def test_withdrawn_product_does_not_exist(self):
+    def test_withdrawn_product_exists(self):
         '''Check if withdrawn products are included in default queryset'''
         # Save product as withdrawn
         self.product.withdrawn = True
         self.product.save()
 
-        with self.assertRaises(Product.DoesNotExist):
+        try:
             _products = Product.objects.get(pk=self.product.pk)
+        except Product.DoesNotExist:
+            self.fail('withdrawn product should be accessible')
 
     def test_products_with_tags_works(self):
         '''Check if with_tags custom query works correctly'''

--- a/project/api/tests/test_product_api.py
+++ b/project/api/tests/test_product_api.py
@@ -252,6 +252,24 @@ class ProductItemTestCase(TestCase):
 
                 self.assertEqual(res.status_code, 404)
 
+    def test_get_returns_withdrawn_product(self):
+        '''Check if GET /product/<id> returns product even if it is withdrawn'''
+        fake = Faker('el_GR')
+        prod = Product(
+            name=fake.first_name(),
+            description=fake.text(max_nb_chars=200, ext_word_list=None),
+            category=fake.word(ext_word_list=None),
+            withdrawn=True
+        )
+        prod.save()
+        
+        request = self.factory.get(self.url)
+        res = self.view(request, pk=prod.pk)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(json.loads(res.content)['withdrawn'], True)
+
+
     def test_put_replaces_existing_product(self):
         '''Check if PUT /products/<id> replaces existing product'''
         req = self.factory.put(self.url, self.new_data)

--- a/project/api/tests/test_shop.py
+++ b/project/api/tests/test_shop.py
@@ -43,14 +43,16 @@ class ShopTestCase(TestCase):
         # Check if shop is accessible from tag
         self.assertTrue(self.shop in tag.shop_set.all())
 
-    def test_withdrawn_shop_does_not_exist(self):
+    def test_withdrawn_shop_exists(self):
         '''Check if withdrawn shops are included in default queryset'''
         # Save shop as withdrawn
         self.shop.withdrawn = True
         self.shop.save()
 
-        with self.assertRaises(Shop.DoesNotExist):
+        try:
             _shops = Shop.objects.get(pk=self.shop.pk)
+        except Shop.DoesNotExist:
+            self.fail('withdrawn shop should be accessible')
 
     def test_shops_within_distance_works(self):
         '''Define a close and a far point and check if within_distance_from queries work correctly'''

--- a/project/api/tests/test_shop_api.py
+++ b/project/api/tests/test_shop_api.py
@@ -270,6 +270,23 @@ class ShopItemTestCase(TestCase):
 
                 self.assertEqual(res.status_code, 404)
 
+    def test_get_returns_withdrawn_shop(self):
+        '''Check if GET /product/<id> returns product even if it is withdrawn'''
+        fake = Faker('el_GR')
+        shop = Shop(
+            name=fake.first_name(),
+            address=fake.address(),
+            coordinates=Point(float(fake.longitude()), float(fake.latitude())),
+            withdrawn=True
+        )
+        shop.save()
+        
+        request = self.factory.get(self.url)
+        res = self.view(request, pk=shop.pk)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(json.loads(res.content)['withdrawn'], True)
+
     def test_put_replaces_existing_shop(self):
         '''Check if PUT /shops/<id> replaces existing shop'''
         req = self.factory.put(self.url, self.new_data)

--- a/project/api/views/product.py
+++ b/project/api/views/product.py
@@ -66,11 +66,11 @@ class ProductsView(View):
 
         # Process `status`
         if status == 'ALL':
-            products = Product._base_manager.all()
-        elif status == 'WITHDRAWN':
-            products = Product._base_manager.filter(withdrawn=True)
-        else: # ACTIVE
             products = Product.objects.all()
+        elif status == 'WITHDRAWN':
+            products = Product.objects.filter(withdrawn=True)
+        else: # ACTIVE
+            products = Product.objects.filter(withdrawn=False)
 
         # Process `start` and `count`
         num_of_products = products.count()

--- a/project/api/views/shop.py
+++ b/project/api/views/shop.py
@@ -70,11 +70,11 @@ class ShopsView(View):
 
         # Process `status`
         if status == 'ALL':
-            shops = Shop._base_manager.all()
-        elif status == 'WITHDRAWN':
-            shops = Shop._base_manager.filter(withdrawn=True)
-        else: # ACTIVE
             shops = Shop.objects.all()
+        elif status == 'WITHDRAWN':
+            shops = Shop.objects.filter(withdrawn=True)
+        else: # ACTIVE
+            shops = Shop.objects.filter(withdrawn=False)
 
         # Process `start` and `count`
         num_of_shops = shops.count()


### PR DESCRIPTION
* Withdrawn objects properly show up on the admin interface
* `GET /products/` and `GET /shops/` still ignore withdrawn objects, this did not change
* `GET /products/ID` and `GET/shops/ID` now properly return information about product/shop, even if it has been withdrawn
* Added `test_get_returns_withdrawn_product`  unit test
* Added `test_get_returns_withdrawn_shop` unit test
* Updated old unit and integration tests for these changes